### PR TITLE
docs: README에 Vercel Preview 링크 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
+## [async-without-sync.vercel.app](async-without-sync.vercel.app)
+
 ## 🔥Frontend Team
-|   오소현 |   김경재                                                                        |   허윤아                                                                          |
-|:---------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------:|
-| <img width="150px" src="https://avatars.githubusercontent.com/u/53892427?v=4" />| <img width="150px" src="https://avatars.githubusercontent.com/u/35104213?v=4" />| <img width="150px" src="https://avatars.githubusercontent.com/u/101046600?v=4" />|
-|  [@osohyun0224](https://github.com/osohyun0224)    |  [@PortalCube](https://github.com/PortalCube)    | [@YoonA](https://github.com/yoona1110)   |
+
+|                                      오소현                                      |                                      김경재                                      |                                      허윤아                                       |
+| :------------------------------------------------------------------------------: | :------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------: |
+| <img width="150px" src="https://avatars.githubusercontent.com/u/53892427?v=4" /> | <img width="150px" src="https://avatars.githubusercontent.com/u/35104213?v=4" /> | <img width="150px" src="https://avatars.githubusercontent.com/u/101046600?v=4" /> |
+|                  [@osohyun0224](https://github.com/osohyun0224)                  |                   [@PortalCube](https://github.com/PortalCube)                   |                      [@YoonA](https://github.com/yoona1110)                       |
 
 ## 💡 Commit Convention
-|Tags |Explanation|
-|:---:|:---:|
-|Feat|새로운 기능 추가|
-|Fix|버그 수정|
-|!BREAKING CHANGE |커다란 API 변경의 경우|
-|!HOTFIX|급한 치명적 버그 수정|
-|Build|빌드 관련 파일 수정|
-|Design|CSS를 포함 UI 디자인 변경|
-|Docs|문서 수정|
-|Style|코드 포맷팅, 세미콜론 누락, 코드 변경 X|
-|Refactor|코드 리팩토링|
-|Comment|필요한 주석 추가 및 변경|
-|Test|테스트 코드 수정|
-|Rename|파일, 폴더명 이름 수정|
-|Remove|파일, 폴더 삭제|
-| chore | 빌드, 패키지 수정|
+
+|       Tags       |               Explanation               |
+| :--------------: | :-------------------------------------: |
+|       Feat       |            새로운 기능 추가             |
+|       Fix        |                버그 수정                |
+| !BREAKING CHANGE |         커다란 API 변경의 경우          |
+|     !HOTFIX      |          급한 치명적 버그 수정          |
+|      Build       |           빌드 관련 파일 수정           |
+|      Design      |        CSS를 포함 UI 디자인 변경        |
+|       Docs       |                문서 수정                |
+|      Style       | 코드 포맷팅, 세미콜론 누락, 코드 변경 X |
+|     Refactor     |              코드 리팩토링              |
+|     Comment      |        필요한 주석 추가 및 변경         |
+|       Test       |            테스트 코드 수정             |
+|      Rename      |         파일, 폴더명 이름 수정          |
+|      Remove      |             파일, 폴더 삭제             |
+|      chore       |            빌드, 패키지 수정            |


### PR DESCRIPTION
## Changes
* docs: README에 Vercel Preview 링크 추가

## Vercel 연결 관련
프론트엔드 레포지토리를 Vercel로 연결했습니다. 이제 레포지토리에 커밋 올릴때마다 Vercel에서 자동으로 [async-without-sync.vercel.app](async-without-sync.vercel.app)에 최신 빌드본을 웹사이트로 퍼블리싱해주니 개발할 때 자유롭게 사용해주세요!

추가로, 축제때와는 달리 이번에는 저희 해커톤 팀에 직접 Vercel을 연결하였습니다. 덕분에 이제 PR을 생성하면 Vercel에서 PR에 대한 Preview도 제공합니다!! (밑에 Vercel의 PR 댓글 참고) PR을 Merge하기 전에 작업한 내용이 어떻게 적용되는지 Vercel에서 제공하는 링크를 통해 확인하실 수 있으니 이것도 유용하게 사용해주시면 감사하겠습니다 :)