### PR TITLE
feat: 이번 달 소비 리포트 페이지 Wireframe 임시 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
+        "dayjs": "^1.11.9",
+        "immer": "^10.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-indiana-drag-scroll": "^3.0.3-alpha",
@@ -16,7 +18,8 @@
         "react-router-dom": "^6.14.2",
         "redux": "^4.2.1",
         "simplebar-react": "^3.2.4",
-        "styled-components": "^6.0.5"
+        "styled-components": "^6.0.5",
+        "use-immer": "^0.9.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.17",
@@ -2453,6 +2456,15 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
@@ -2502,7 +2514,7 @@
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
       "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3046,6 +3058,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3894,9 +3911,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -5574,6 +5591,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-immer": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.9.0.tgz",
+      "integrity": "sha512-/L+enLi0nvuZ6j4WlyK0US9/ECUtV5v9RUbtxnn5+WbtaXYUaOBoKHDNL9I5AETdurQ4rIFIj/s+Z5X80ATyKw==",
+      "peerDependencies": {
+        "immer": ">=2.0.0",
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
+    "dayjs": "^1.11.9",
+    "immer": "^10.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-indiana-drag-scroll": "^3.0.3-alpha",
@@ -20,7 +22,8 @@
     "react-router-dom": "^6.14.2",
     "redux": "^4.2.1",
     "simplebar-react": "^3.2.4",
-    "styled-components": "^6.0.5"
+    "styled-components": "^6.0.5",
+    "use-immer": "^0.9.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.17",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import SignupPage from "./pages/LoginSignup/SignupPage.jsx";
 import PasswordPage from "./pages/LoginSignup/PasswordPage.jsx";
 import SignCompelete from "./pages/LoginSignup/SignCompelete.jsx";
 import AccountBookPage from "./pages/account-book/AccountBookPage.jsx";
+import MonthlySummaryPage from "./pages/account-book/MonthlySummaryPage.jsx";
 import MyPetPage from "./pages/my-pet/MyPetPage.jsx";
 import HeaderPage from "./pages/HeaderPage.jsx";
 import Main from "./pages/Main.jsx";
@@ -29,6 +30,10 @@ function App() {
           <Route element={<HeaderPage />}>
             <Route path="/main" element={<Main />} />
             <Route path="/account-book" element={<AccountBookPage />} />
+            <Route
+              path="/account-book/summary"
+              element={<MonthlySummaryPage />}
+            />
             <Route path="/my-pet" element={<MyPetPage />} />
           </Route>
         </Routes>

--- a/src/components/account-book/Button.jsx
+++ b/src/components/account-book/Button.jsx
@@ -1,0 +1,41 @@
+import PropTypes from "prop-types";
+
+import { styled } from "styled-components";
+
+const Btn = styled.button`
+  width: 100%;
+  margin-top: 12px;
+  padding: 8px 0;
+  border: none;
+  border-radius: 6px;
+  background-color: rgba(217, 74, 86, 1);
+  color: #ffffff;
+  font-size: 16px;
+  cursor: pointer;
+
+  &.outline {
+    background-color: #ffffff;
+    border: 2px solid rgba(217, 74, 86, 1);
+    color: rgba(217, 74, 86, 1);
+  }
+`;
+
+const Button = ({ className, children, outline = false, onClick }) => {
+  return (
+    <Btn
+      className={[className, outline ? "outline" : ""].join(" ")}
+      onClick={onClick}
+    >
+      {children}
+    </Btn>
+  );
+};
+
+Button.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  outline: PropTypes.bool,
+  onClick: PropTypes.func,
+};
+
+export default Button;

--- a/src/components/account-book/CalenderItem.jsx
+++ b/src/components/account-book/CalenderItem.jsx
@@ -1,0 +1,50 @@
+import PropTypes from "prop-types";
+
+import { styled } from "styled-components";
+
+const Container = styled.div`
+  width: 100%;
+  height: 50px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: #dfdfdf;
+  }
+`;
+
+const Text = styled.p`
+  font-size: 16px;
+  font-weight: 700;
+`;
+
+const Price = styled.p`
+  font-size: 9px;
+  font-weight: 400;
+`;
+
+const CalenderItem = ({ date, value, color }) => {
+  return (
+    <Container>
+      <Text style={{ color }}>{date}</Text>
+      <Price style={{ visibility: value > 0 ? "visible" : "hidden" }}>
+        {value >= 10000000
+          ? value.toLocaleString("ko-KR", { notation: "compact" })
+          : value.toLocaleString()}
+      </Price>
+    </Container>
+  );
+};
+
+CalenderItem.propTypes = {
+  date: PropTypes.string,
+  value: PropTypes.number,
+  color: PropTypes.string,
+};
+
+export default CalenderItem;

--- a/src/components/account-book/CircularChart.jsx
+++ b/src/components/account-book/CircularChart.jsx
@@ -43,10 +43,12 @@ const CircularChart = ({ className, data }) => {
 
 CircularChart.propTypes = {
   className: PropTypes.string,
-  data: PropTypes.shape({
-    color: PropTypes.string,
-    value: PropTypes.number,
-  }),
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      color: PropTypes.string,
+      value: PropTypes.number,
+    }),
+  ),
 };
 
 export default CircularChart;

--- a/src/components/account-book/SummaryCalender.jsx
+++ b/src/components/account-book/SummaryCalender.jsx
@@ -1,0 +1,114 @@
+import PropTypes from "prop-types";
+
+import { styled } from "styled-components";
+
+import CalenderItem from "./CalenderItem.jsx";
+
+import dayjs from "dayjs";
+import arraySupport from "dayjs/plugin/arraySupport";
+
+dayjs.extend(arraySupport);
+
+const Select = styled.select`
+  margin-left: -2px;
+  border: none;
+  font-size: 20px;
+  font-weight: 700;
+  cursor: pointer;
+`;
+
+const TotalAmount = styled.p`
+  font-size: 32px;
+  font-weight: 700;
+`;
+
+const CalenderContainer = styled.div`
+  width: 100%;
+  margin-top: 23px;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-gap: 4px;
+`;
+
+const data = [
+  { date: 4, value: 5600 },
+  { date: 6, value: 12000 },
+  { date: 7, value: 40230 },
+  { date: 10, value: 20230 },
+  { date: 16, value: 1030 },
+  { date: 20, value: 390230 },
+  { date: 24, value: 120230 },
+  { date: 25, value: 320230 },
+  { date: 28, value: 820230 },
+];
+
+const SummaryCalender = () => {
+  const current = dayjs();
+  const year = current.year();
+  const month = current.month();
+  const start = dayjs([year, month]).day(0); // 매월 첫째날을 기준 주로, 일요일 date 값을 가져오기
+
+  const list = [];
+
+  const disabledColor = "rgba(21, 21, 21, 0.25)";
+  const mainColor = "rgba(21, 21, 21, 1)";
+  const todayColor = "rgba(242, 211, 53, 1)";
+  const saturdayColor = "rgba(54, 162, 235, 1)";
+  const sundayColor = "rgba(217, 74, 86, 1)";
+
+  for (let i = 0; i < 35; i++) {
+    const date = start.add(i, "day");
+
+    let color = mainColor;
+
+    if (month !== date.month()) {
+      color = disabledColor;
+    } else if (
+      date.month() === current.month() &&
+      date.date() === current.date()
+    ) {
+      color = todayColor;
+    } else if (date.day() === 0) {
+      color = sundayColor;
+    } else if (date.day() === 6) {
+      color = saturdayColor;
+    }
+
+    const find = data.find(
+      (item) => month === date.month() && item.date === date.date(),
+    );
+
+    list.push({
+      id: `${year}-${month}-${i}`,
+      month: date.month(),
+      date: date.date(),
+      color,
+      value: find ? find.value : 0,
+    });
+  }
+
+  return (
+    <>
+      <Select>
+        <option value="">2023년 8월</option>
+        <option value="1">2023년 9월</option>
+        <option value="2">2023년 10월</option>
+      </Select>
+      <TotalAmount>504,000원</TotalAmount>
+      <CalenderContainer>
+        {list.map((item) => (
+          <CalenderItem
+            key={item.id}
+            date={item.date}
+            value={item.value}
+            color={item.color}
+          />
+        ))}
+      </CalenderContainer>
+    </>
+  );
+};
+
+SummaryCalender.propTypes = {};
+
+export default SummaryCalender;

--- a/src/pages/account-book/AccountBookPage.jsx
+++ b/src/pages/account-book/AccountBookPage.jsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { styled } from "styled-components";
+import { Link } from "react-router-dom";
 
+import Button from "../../components/account-book/Button.jsx";
 import Expense from "../../components/account-book/Expense.jsx";
 import ExpenseInfomation from "../../components/account-book/ExpenseInfomation.jsx";
 import MonthlyExpense from "../../components/account-book/MonthlyExpense.jsx";
@@ -10,16 +12,8 @@ const Container = styled.div`
   margin: 8px 32px;
 `;
 
-const Button = styled.button`
-  width: 100%;
-  margin-top: 12px;
-  padding: 8px 0;
-  border: none;
-  border-radius: 6px;
-  background-color: rgba(217, 74, 86, 1);
-  color: #ffffff;
-  font-size: 16px;
-  cursor: pointer;
+const StyledLink = styled(Link)`
+  text-decoration: none;
 `;
 
 const initialExpense = 700000;
@@ -77,7 +71,9 @@ const AccountBookPage = () => {
   return (
     <Container>
       <Expense value={expense} />
-      <Button>이번달 소비 보기</Button>
+      <StyledLink to="/account-book/summary">
+        <Button>이번달 소비 보기</Button>
+      </StyledLink>
       <ExpenseInfomation value={expenseChange} />
       <MonthlyExpense data={monthlyData} />
       <DailyExpense date="8월 7일" data={initialDailyData} />

--- a/src/pages/account-book/MonthlySummaryPage.jsx
+++ b/src/pages/account-book/MonthlySummaryPage.jsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+import { styled } from "styled-components";
+
+import Button from "../../components/account-book/Button.jsx";
+import SummaryCalender from "../../components/account-book/SummaryCalender.jsx";
+
+const Container = styled.div`
+  margin: 8px 32px;
+`;
+
+const MonthlySummaryPage = () => {
+  return (
+    <Container>
+      <SummaryCalender />
+    </Container>
+  );
+};
+
+export default MonthlySummaryPage;


### PR DESCRIPTION
<img src="https://github.com/Likelion-MainHackaton-2team/Frontend_Dev_Repo/assets/35104213/3efa6a20-f6cc-42e3-93f4-1f40562d31f4" width="500"/>

## Changes
* 이번 달 소비 리포트 페이지 달력 부분 작업했습니다. (아직 미완)
* 추후 나머지 부분 이어서 만들 예정입니다....

## Issue
* 작은 기기 (갤럭시 폴드 전면 화면)에서 공간이 모잘라서 컴포넌트 잘리는 문제
  * 축약 표현 (120,000 -> 12만 or 1,140,000 -> 114만) 을 사용하여 해결?? -> 디자인쪽과 의논 예정