### PR TITLE
Feat: MyPet 추가 모달창 구현 / 입력 폼 공공재 만들어둠

### DIFF
--- a/src/components/InputForm.jsx
+++ b/src/components/InputForm.jsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const InputField = styled.input`
+  width: 291px;
+  height: 40px;
+  border-radius: 5px;
+  background: #F8F8F8;
+  border: none;
+  padding: 10px;
+`;
+
+const InputForm = ({ placeholder }) => {
+  return (
+    <InputField
+      type="text"
+      placeholder={placeholder}
+    />
+  );
+};
+
+InputForm.propTypes = {
+  placeholder: PropTypes.string,
+};
+
+export default InputForm;

--- a/src/components/my-pet/MyPetInputModal.jsx
+++ b/src/components/my-pet/MyPetInputModal.jsx
@@ -34,7 +34,7 @@ const ModalHeader = styled.div`
   margin-top: 20px;
 `;
 
-const ImageBox = styled.div`
+const ImageBox = styled.label`
   width: 118px;
   height: 118px;
   position: absolute;
@@ -47,6 +47,23 @@ const ImageBox = styled.div`
   align-items: center;
   justify-content: center;
   gap: 10px;
+  background: #FFFFFF;
+  cursor: pointer;
+`;
+
+const ImageInput = styled.input`
+  display: none;
+`;
+
+const ImageText = styled.p`
+  font-family: Nanum Gothic;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+  letter-spacing: -0.02em;
+  text-align: center;
+  margin: 0; 
+  color: #F2D335;
 `;
 
 
@@ -58,8 +75,9 @@ const MyPetInputModal = ({ show, onClose }) => {
     <ModalOverlay onClick={onClose}>
       <ModalWrapper onClick={e => e.stopPropagation()}>
         <ModalHeader>추가하기</ModalHeader>
-        <ImageBox>
-          <input type="file" accept="image/*" />
+        <ImageBox htmlFor="fileInput">
+          <ImageInput type="file" accept="image/*" id="fileInput" />
+          <ImageText>이미지를 <br/> 추가해주세요</ImageText>
         </ImageBox>
       </ModalWrapper>
     </ModalOverlay>

--- a/src/components/my-pet/MyPetInputModal.jsx
+++ b/src/components/my-pet/MyPetInputModal.jsx
@@ -1,7 +1,6 @@
-import styled from 'styled-components';
-import PropTypes from 'prop-types';
-
-
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import InputForm from "../../components/InputForm.jsx";
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -21,7 +20,7 @@ const ModalWrapper = styled.div`
   height: 469px;
   position: relative;
   border-radius: 5px;
-  background: #FFFFFF;
+  background: #ffffff;
 `;
 
 const ModalHeader = styled.div`
@@ -42,12 +41,12 @@ const ImageBox = styled.label`
   left: 135px;
   padding: 2px 6px 2px 6px;
   border-radius: 5px;
-  border: 1px solid #F2D335;
+  border: 1px solid #f2d335;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 10px;
-  background: #FFFFFF;
+  background: #ffffff;
   cursor: pointer;
 `;
 
@@ -62,28 +61,45 @@ const ImageText = styled.p`
   line-height: 20px;
   letter-spacing: -0.02em;
   text-align: center;
-  margin: 0; 
-  color: #F2D335;
+  margin: 0;
+  color: #f2d335;
 `;
 
+const NameHeader = styled.div`
+  font-family: NanumGothic;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 30px;
+  letter-spacing: -0.02em;
+  text-align: left;
+
+  font-family: NanumGothic;
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 30px;
+  letter-spacing: -0.02em;
+  text-align: left;
+`;
 
 const MyPetInputModal = ({ show, onClose }) => {
   if (!show) return null;
-  
 
   return (
     <ModalOverlay onClick={onClose}>
-      <ModalWrapper onClick={e => e.stopPropagation()}>
+      <ModalWrapper onClick={(e) => e.stopPropagation()}>
         <ModalHeader>추가하기</ModalHeader>
         <ImageBox htmlFor="fileInput">
           <ImageInput type="file" accept="image/*" id="fileInput" />
-          <ImageText>이미지를 <br/> 추가해주세요</ImageText>
+          <ImageText>
+            이미지를 <br /> 추가해주세요
+          </ImageText>
         </ImageBox>
+        <NameHeader>이름 * </NameHeader> 
+        <InputForm placeholder="이름" />
       </ModalWrapper>
     </ModalOverlay>
   );
 };
-
 
 MyPetInputModal.propTypes = {
   show: PropTypes.bool.isRequired,

--- a/src/components/my-pet/MyPetInputModal.jsx
+++ b/src/components/my-pet/MyPetInputModal.jsx
@@ -1,0 +1,75 @@
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  box-shadow: 0px 2px 4px 0px #00000040;
+`;
+
+const ModalWrapper = styled.div`
+  width: 321px;
+  height: 469px;
+  position: relative;
+  border-radius: 5px;
+  background: #FFFFFF;
+`;
+
+const ModalHeader = styled.div`
+  font-family: Nanum Gothic;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 22px;
+  letter-spacing: -0.02em;
+  text-align: center;
+  margin-top: 20px;
+`;
+
+const ImageBox = styled.div`
+  width: 118px;
+  height: 118px;
+  position: absolute;
+  top: 222px;
+  left: 135px;
+  padding: 2px 6px 2px 6px;
+  border-radius: 5px;
+  border: 1px solid #F2D335;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+`;
+
+
+const MyPetInputModal = ({ show, onClose }) => {
+  if (!show) return null;
+  
+
+  return (
+    <ModalOverlay onClick={onClose}>
+      <ModalWrapper onClick={e => e.stopPropagation()}>
+        <ModalHeader>추가하기</ModalHeader>
+        <ImageBox>
+          <input type="file" accept="image/*" />
+        </ImageBox>
+      </ModalWrapper>
+    </ModalOverlay>
+  );
+};
+
+
+MyPetInputModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default MyPetInputModal;

--- a/src/pages/my-pet/MyPetPage.jsx
+++ b/src/pages/my-pet/MyPetPage.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { styled } from "styled-components";
 
-// 부드러운 스크롤 라이브러리
 import { useScrollContainer } from "react-indiana-drag-scroll";
 import "react-indiana-drag-scroll/dist/style.css";
 
@@ -10,6 +9,7 @@ import MyPetList from "../../components/my-pet/MyPetList.jsx";
 import MyPetListItem from "../../components/my-pet/MyPetListItem.jsx";
 
 import AddPetImage from "../../assets/images/addPet.png";
+import MyPetAddModal from "../../components/my-pet/MyPetInputModal.jsx";
 
 const Container = styled.div`
   margin: 12px 16px;
@@ -53,22 +53,17 @@ const MyPetPage = () => {
     },
   ];
 
-  // const [petList, setPetList] = useState([]);
-  const [petList, setPetList] = useState(samplePetListData);
+    const [petList] = useState(samplePetListData);
   const [pet, setPet] = useState(samplePetListData[0]);
+  const [showModal, setShowModal] = useState(false);
 
-  function AddPet() {
-    const name = prompt("이름을 지어주세요!");
+  const handleOpenModal = () => {
+    setShowModal(true);
+  };
 
-    setPetList([
-      ...petList,
-      {
-        id: petList[petList.length - 1] ?? 1,
-        image: "https://placehold.co/64",
-        name,
-      },
-    ]);
-  }
+  const handleCloseModal = () => {
+    setShowModal(false);
+  };
 
   return (
     <Container>
@@ -86,11 +81,12 @@ const MyPetPage = () => {
             }}
           />
         ))}
-        <MyPetListItem src={AddPetImage} name="추가하기" onClick={AddPet} />
+        <MyPetListItem src={AddPetImage} name="추가하기" onClick={handleOpenModal} />
       </MyPetList>
       <Heading>
         <HeadingBold>{pet.name}</HeadingBold>의 정보
       </Heading>
+      <MyPetAddModal show={showModal} onClose={handleCloseModal} />
     </Container>
   );
 };

--- a/src/pages/my-pet/MyPetPage.jsx
+++ b/src/pages/my-pet/MyPetPage.jsx
@@ -11,6 +11,8 @@ import MyPetListItem from "../../components/my-pet/MyPetListItem.jsx";
 import AddPetImage from "../../assets/images/addPet.png";
 import MyPetAddModal from "../../components/my-pet/MyPetInputModal.jsx";
 
+
+
 const Container = styled.div`
   margin: 12px 16px;
 `;

--- a/src/pages/my-pet/MyPetPage.jsx
+++ b/src/pages/my-pet/MyPetPage.jsx
@@ -53,16 +53,24 @@ const MyPetPage = () => {
     },
   ];
 
-    const [petList] = useState(samplePetListData);
+  const [petList] = useState(samplePetListData);
   const [pet, setPet] = useState(samplePetListData[0]);
   const [showModal, setShowModal] = useState(false);
 
+  const handleModalToggle = (isOpen) => {
+    if (ref.current) {
+      ref.current.style.overflow = isOpen ? 'hidden' : 'auto';
+    }
+  };
+  
   const handleOpenModal = () => {
     setShowModal(true);
+    handleModalToggle(true);
   };
-
+  
   const handleCloseModal = () => {
     setShowModal(false);
+    handleModalToggle(false);
   };
 
   return (


### PR DESCRIPTION
1) MyPet 추가 모달창 구현해두었습니다.
- 다른 페이지에서도 모달창 쓰길래 모달창 기본 버전(오버레이, 모달창 크기 등)도 공공재로 만들어두었습니다. 제꺼는 my-pet 안에 있고 공공재로 쓰실분은 컴포넌트 루트파일에서 찾아서 쓰시면 됩니다.

2) 입력폼 공공재
- 입력폼도 컴포넌트 루트파일에 공공재로 넣어놨습니다.

**3. To 경재씌**
그 경재가 마이펫 처음 구현할 때 넣은 scrollableNodeProps 이게 내가 모달창을 열면 모달창에서도 보여서 이거 모달창 열였을때에는 안보이게 할 려고 찾아봣는데 여러방법해봣는데도 안됨... useScrollContainer 훅의 API도 봤느데 ... 실패함 혹시 이거 라이브러리의 내부 동작과 관련된 문제인가요...? 흑흑 도와주세요ㅜㅜ


![image](https://github.com/Likelion-MainHackaton-2team/Frontend_Dev_Repo/assets/53892427/c745fe90-b68e-4891-99f4-67aacb2158fc)

